### PR TITLE
Replace use of OpaqueToken to make Angular 5.x ready

### DIFF
--- a/src/lib/dropzone.module.ts
+++ b/src/lib/dropzone.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, OpaqueToken, Optional, SkipSelf, Inject } from '@angular/core';
+import { NgModule, ModuleWithProviders, InjectionToken, Optional, SkipSelf, Inject } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
 
@@ -6,8 +6,8 @@ import { DropzoneComponent } from './dropzone.component';
 import { DropzoneDirective } from './dropzone.directive';
 import { DropzoneConfig, DropzoneConfigInterface} from './dropzone.interfaces';
 
-export const DROPZONE_GUARD = new OpaqueToken('DROPZONE_GUARD');
-export const DROPZONE_CONFIG = new OpaqueToken('DROPZONE_CONFIG');
+export const DROPZONE_GUARD = new InjectionToken('DROPZONE_GUARD');
+export const DROPZONE_CONFIG = new InjectionToken('DROPZONE_CONFIG');
 
 @NgModule({
   imports: [CommonModule],


### PR DESCRIPTION
`OpaqueToken` has been deprecated since Angular 4.x and has been removed in Angular 5.x https://github.com/angular/angular/pull/18971

My project currently uses your project (thank you!) and I'm working on adding in/testing some functionality that depends on Angular 5.x. `ngx-dropzone-wrapper` seems to be the only dependency that has issues with Angular 5.x.