### PR TITLE
Update dropzone.interfaces.ts

### DIFF
--- a/src/lib/dropzone.interfaces.ts
+++ b/src/lib/dropzone.interfaces.ts
@@ -105,6 +105,7 @@ export interface DropzoneConfigInterface {
 
   dictRemoveFile?: string,
   dictCancelUpload?: string,
+  dictUploadCanceled?: string,
   dictFallbackText?: string,
   dictMaxFilesExceeded?: string,
   dictRemoveFileConfirmation?: string,
@@ -181,6 +182,7 @@ export class DropzoneConfig implements DropzoneConfigInterface {
 
   dictRemoveFile: string;
   dictCancelUpload: string;
+  dictUploadCanceled: string;
   dictFallbackText: string;
   dictMaxFilesExceeded: string;
   dictRemoveFileConfirmation: string;


### PR DESCRIPTION
While using this repo, I observed that the configuration interface is missing a key "dictUploadCanceled".
As you can check [here](https://gitlab.com/meno/dropzone/blob/18f1a41910c481632cce1963ec9da91defb1a825/CHANGELOG.md#anchor-530), this key was added in version 5.3.0 of dropzone but somehow it was not existing here.

It is now been added in configuration interface. - Fixed.