### PR TITLE
Changes the order the default message is selected

### DIFF
--- a/src/lib/dropzone.component.html
+++ b/src/lib/dropzone.component.html
@@ -1,6 +1,6 @@
 <div class="dz-wrapper" [class.dropzone]="useDropzoneClass" [dropzone]="config" [disabled]="disabled">
   <div class="dz-message" [class.disabled]="disabled" [class.dz-placeholder]="placeholder">
-    <div class="dz-text" [innerHTML]="message || config?.dictDefaultMessage"></div>
+    <div class="dz-text" [innerHTML]="config?.dictDefaultMessage || message"></div>
 
     <div *ngIf="placeholder" class="dz-image" [style.background-image]="getPlaceholder()"></div>
   </div>


### PR DESCRIPTION
The way the order is decided, the default message is always preferred instead of the configured message.

A small workaround for this is setting:
```html
<dropzone [message]="dropzoneConfig.dictDefaultMessage"></dropzone>
```