### PR TITLE
Remove unwanted console.log

### DIFF
--- a/projects/lib/src/lib/dropzone.directive.ts
+++ b/projects/lib/src/lib/dropzone.directive.ts
@@ -117,7 +117,6 @@ export class DropzoneDirective
     Object.keys(params).forEach(key => params[key] === undefined && delete params[key])
 
     this.zone.runOutsideAngular(() => {
-      console.log(params);
       this.instance = new Dropzone(this.elementRef.nativeElement, params);
     });
 


### PR DESCRIPTION
Removing unwanted console.log in dropzone.directive.ts

Fixed [186](https://github.com/zefoy/ngx-dropzone-wrapper/issues/186)